### PR TITLE
Add command for skipping if binary is below a certain version

### DIFF
--- a/src/query.go
+++ b/src/query.go
@@ -126,6 +126,7 @@ const (
 	Q_COMMENT
 	Q_COMMENT_WITH_COMMAND
 	Q_EMPTY_LINE
+	Q_SKIP_IF_BELOW_VERSION
 )
 
 // ParseQueries parses an array of string into an array of query object.
@@ -192,7 +193,7 @@ func (q *query) getQueryType(qu string) error {
 	} else {
 		// No mysqltest command matched
 		if q.tp != Q_COMMENT_WITH_COMMAND {
-			// A query that will sent to tidb
+			// A query that will sent to vitess
 			q.Query = qu
 			q.tp = Q_QUERY
 		} else {

--- a/src/type.go
+++ b/src/type.go
@@ -114,6 +114,7 @@ var commandMap = map[string]CmdType{
 	"single_query":               Q_SINGLE_QUERY,
 	"begin_concurrent":           Q_BEGIN_CONCURRENT,
 	"end_concurrent":             Q_END_CONCURRENT,
+	"skip_if_below_version":      Q_SKIP_IF_BELOW_VERSION,
 }
 
 func findType(cmdName string) CmdType {


### PR DESCRIPTION
### Description

This PR makes 2 changes - 
1. It adds a command to the tester to allow it to skip queries based on the version of binaries. This is similar to what we employ in vitess's end to end test setup with `SkipIfBinaryBelowVersion`.
2. Instead of printing the Vschema once, we print the vschema in each error file, because the vscehma can change as part of the execution of the test so it makes sense to print it separately for each query.