### PR TITLE
Add custom vindex definition

### DIFF
--- a/src/tester.go
+++ b/src/tester.go
@@ -372,7 +372,8 @@ func (t *tester) executeStmt(query string) error {
 
 	log.Debugf("executeStmt: %s", query)
 	create, isCreateStatement := ast.(*sqlparser.CreateTable)
-	if isCreateStatement && !t.expectedErrs {
+	autoVschema := isCreateStatement && !t.expectedErrs && vschemaFile == ""
+	if autoVschema {
 		t.handleCreateTable(create)
 	}
 
@@ -387,7 +388,7 @@ func (t *tester) executeStmt(query string) error {
 		_ = t.curr.Exec(query)
 	}
 
-	if isCreateStatement && !t.expectedErrs {
+	if autoVschema {
 		err = utils.WaitForAuthoritative(t, keyspaceName, create.Table.Name.String(), clusterInstance.VtgateProcess.ReadVSchema)
 		if err != nil {
 			panic(err)

--- a/t/tpch_vschema.json
+++ b/t/tpch_vschema.json
@@ -1,0 +1,114 @@
+{
+  "routing_rules": null,
+  "shard_routing_rules": null,
+  "keyspace_routing_rules": null,
+  "keyspaces": {
+    "mysqltest": {
+      "sharded": true,
+      "foreignKeyMode": "unspecified",
+      "vindexes": {
+        "xxhash": {
+          "type": "xxhash"
+        }
+      },
+      "tables": {
+        "customer": {
+          "name": "customer",
+          "column_vindexes": [
+            {
+              "column": "C_CUSTKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "lineitem": {
+          "name": "lineitem",
+          "column_vindexes": [
+            {
+              "columns": [
+                "L_ORDERKEY",
+                "L_LINENUMBER"
+              ],
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "nation": {
+          "name": "nation",
+          "column_vindexes": [
+            {
+              "column": "N_NATIONKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "orders": {
+          "name": "orders",
+          "column_vindexes": [
+            {
+              "column": "O_ORDERKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "part": {
+          "name": "part",
+          "column_vindexes": [
+            {
+              "column": "P_PARTKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "partsupp": {
+          "name": "partsupp",
+          "column_vindexes": [
+            {
+              "columns": [
+                "PS_PARTKEY",
+                "PS_SUPPKEY"
+              ],
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "region": {
+          "name": "region",
+          "column_vindexes": [
+            {
+              "column": "R_REGIONKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "supplier": {
+          "name": "supplier",
+          "column_vindexes": [
+            {
+              "column": "S_SUPPKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        },
+        "test": {
+          "name": "test",
+          "column_vindexes": [
+            {
+              "column": "S_SUPPKEY",
+              "name": "xxhash",
+              "type": "xxhash"
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A new flag is introduced: `-vschema` which takes the path to a custom vschema, so we can run the vitess-tester with our own vschema instead of relying on the auto-vschema feature.

```
./vitess-tester -sharded -vschema=./t/tpch_vschema.json tpch
```