### PR TITLE
Use full path for test files and remove `-test-dir`

### DIFF
--- a/src/vitess-tester/tester.go
+++ b/src/vitess-tester/tester.go
@@ -36,7 +36,6 @@ import (
 )
 
 type tester struct {
-	dir  string
 	name string
 
 	clusterInstance       *cluster.LocalProcessCluster
@@ -59,14 +58,14 @@ type tester struct {
 	reporter Reporter
 }
 
-func NewTester(name string, reporter Reporter,
+func NewTester(
+	name string,
+	reporter Reporter,
 	clusterInstance *cluster.LocalProcessCluster,
-	vtParams,
-	mysqlParams mysql.ConnParams,
+	vtParams, mysqlParams mysql.ConnParams,
 	olap bool,
 	keyspaceName string,
 	vschema vindexes.VSchema,
-	dir string,
 	vschemaFile string,
 ) *tester {
 	t := &tester{
@@ -78,7 +77,6 @@ func NewTester(name string, reporter Reporter,
 		keyspaceName:    keyspaceName,
 		vschema:         vschema,
 		vschemaFile:     vschemaFile,
-		dir:             dir,
 		olap:            olap,
 	}
 	return t
@@ -275,7 +273,7 @@ func (t *tester) readData() ([]byte, error) {
 		defer res.Body.Close()
 		return io.ReadAll(res.Body)
 	}
-	return os.ReadFile(t.testFileName())
+	return os.ReadFile(t.name)
 }
 
 func (t *tester) execute(query query) error {
@@ -400,10 +398,6 @@ func (t *tester) handleCreateTable(create *sqlparser.CreateTable) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-func (t *tester) testFileName() string {
-	return fmt.Sprintf("%s/%s.test", t.dir, t.name)
 }
 
 func (t *tester) Errorf(format string, args ...interface{}) {


### PR DESCRIPTION
The goal of this PR is to make it easier to use our own `.test` file when using the vitess-tester. We now expect the full path to the file we want to run in the test. This will allow us to run different files located in different directories, use `*` and al in the shell when referencing test files.