### PR TITLE
Fix map init in `getKeyspaces` and type casting of vschema

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,14 +208,20 @@ func getKeyspaces() []*cluster.Keyspace {
 	}
 
 	var keyspaces []*cluster.Keyspace
+	var err error
 	for key, value := range ksRaw.Keyspaces {
-		ksSchema, err := json.Marshal(value)
-		if err != nil {
-			panic(err.Error())
+		var ksSchema string
+		valueRaw, ok := value.([]uint8)
+		if !ok {
+			valueRaw, err = json.Marshal(value)
+			if err != nil {
+				panic(err.Error())
+			}
 		}
+		ksSchema = string(valueRaw)
 		keyspaces = append(keyspaces, &cluster.Keyspace{
 			Name:    key,
-			VSchema: string(ksSchema),
+			VSchema: ksSchema,
 		})
 	}
 	return keyspaces

--- a/main.go
+++ b/main.go
@@ -188,7 +188,10 @@ func setupCluster() (clusterInstance *cluster.LocalProcessCluster, vtParams, mys
 }
 
 func getKeyspaces() []*cluster.Keyspace {
-	var ksRaw rawKeyspaceVindex
+	ksRaw := rawKeyspaceVindex{
+		Keyspaces: map[string]interface{}{},
+	}
+
 	if vschemaFile != "" {
 		ksRaw = readVschema(vschemaFile, false)
 	} else if vtexplainVschemaFile != "" {


### PR DESCRIPTION
This fixes two small issues:
- The `rawKeyspaceVindex.Keyspace` map was not init
- When running with auto-vschema the vschema was not translated properly leading to errors