### PR TITLE
Fix nil bug 

### DIFF
--- a/src/vitess-tester/tester.go
+++ b/src/vitess-tester/tester.go
@@ -83,7 +83,9 @@ func NewTester(
 		vschema:         vschema,
 		vschemaFile:     vschemaFile,
 		olap:            olap,
-		traceFile:       traceFile,
+	}
+	if traceFile != nil {
+		t.traceFile = traceFile
 	}
 	return t
 }


### PR DESCRIPTION
We recently broke `main` by merging this faulty logic, which lead to `vitess-tester` only working when tracing.